### PR TITLE
Fix tsconfig missing libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,9 @@
       "noImplicitAny": true,
       "module": "CommonJS",
       "target": "es5",
-      "allowJs": true
+      "allowJs": true,
+      "lib": ["dom", "es2015"],
+      "skipLibCheck": true,
+      "types": []
     }
 }


### PR DESCRIPTION
## Summary
- tune TypeScript compiler options so it doesn't expect extra type libraries
- provide ES2015 lib types and skip checking bundled declarations

## Testing
- `npm run build`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68546fb37ebc8326b1efd88fe94d6f6d