### PR TITLE
Fix camera reset orientation relative to character

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,12 @@ const rotationSpeed = 0.005;
 function smoothReset(duration = 1) {
     const startPos = camera.position.clone();
     const startTarget = orbitControls.target.clone();
-    const endTarget = startTarget.clone();
-    const endPos = startTarget.clone().add(resetOffset);
+
+    const modelQuat = characterControls ? characterControls.model.quaternion : new THREE.Quaternion();
+    const endTarget = characterControls ? characterControls.cameraTarget.clone() : startTarget.clone();
+    const endOffset = resetOffset.clone().applyQuaternion(modelQuat);
+    const endPos = endTarget.clone().add(endOffset);
+
     const startTime = performance.now();
 
     function animate(time: number) {


### PR DESCRIPTION
## Summary
- rotate reset offset by character orientation before moving camera
- keep camera behind character when idle

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68556a943d8c8326ad70ecbdd2823404